### PR TITLE
Add more API to get Edwood working

### DIFF
--- a/color.go
+++ b/color.go
@@ -5,11 +5,8 @@ package draw
 type Color uint32
 
 const (
-	Transparent Color = 0x00000000 /* only useful for allocimage memfillcolor */
-	White       Color = 0xFFFFFFFF
-
-/*
 	Opaque        Color = 0xFFFFFFFF
+	Transparent   Color = 0x00000000 /* only useful for allocimage memfillcolor */
 	Black         Color = 0x000000FF
 	White         Color = 0xFFFFFFFF
 	Red           Color = 0xFF0000FF
@@ -37,5 +34,4 @@ const (
 
 	Notacolor Color = 0xFFFFFF00
 	Nofill    Color = Notacolor
-*/
 )

--- a/font.go
+++ b/font.go
@@ -129,6 +129,18 @@ func (f *Font) StringWidth(s string) int {
 	return dx
 }
 
+// ByteWidth returns the number of horizontal pixels that would be occupied by
+// the byte slice if it were drawn using the font.
+func (f *Font) BytesWidth(b []byte) int {
+	return f.StringWidth(string(b))
+}
+
+// RuneWidth returns the number of horizontal pixels that would be occupied by
+// the rune slice if it were drawn using the font.
+func (f *Font) RunesWidth(r []rune) int {
+	return f.StringWidth(string(r))
+}
+
 // pixFace wraps a font.Face which ignores Kern and advances only by full pixels.
 // Duit calls StringWidth on each rune to calculate coordinates and uses only ints.
 type pixFace struct {

--- a/image.go
+++ b/image.go
@@ -16,6 +16,8 @@ type Image struct {
 	sync.Mutex                 // Locking is used only internally.
 	R          image.Rectangle // The extent of the image.
 	m          image.Image
+	Display    *Display
+	Pix        Pix // The pixel format for the image.
 }
 
 // Draw copies the source image with upper left corner p1 to the destination
@@ -73,6 +75,10 @@ func (dst *Image) Load(r image.Rectangle, data []byte) (int, error) {
 
 	// Is len(data) ok? Duit does not read the first argument anyway.
 	return len(data), nil
+}
+
+func (dst *Image) Bytes(pt image.Point, src *Image, sp image.Point, f *Font, b []byte) image.Point {
+	return dst.String(pt, src, sp, f, string(b))
 }
 
 // String draws the string in the specified font using SoverD on the image,

--- a/init.go
+++ b/init.go
@@ -52,18 +52,23 @@ func newWindow(label, winsize, fontname string) (*Display, screen.NewWindowOptio
 
 	dpy := Display{
 		DPI: DefaultDPI,
-		Black: &Image{
-			R: image.Rect(0, 0, 1, 1),
-			m: image.NewUniform(color.Black),
-		},
-		White: &Image{
-			R: image.Rect(0, 0, 1, 1),
-			m: image.NewUniform(color.White),
-		},
-		ScreenImage: &Image{
-			R: image.Rect(0, 0, opt.Width, opt.Height),
-			// m will be backed by screen.Buffer on size event.
-		},
+	}
+	dpy.Black = &Image{
+		Display: &dpy,
+		R:       image.Rect(0, 0, 1, 1),
+		m:       image.NewUniform(color.Black),
+	}
+	dpy.White = &Image{
+		Display: &dpy,
+		R:       image.Rect(0, 0, 1, 1),
+		m:       image.NewUniform(color.White),
+	}
+	dpy.Opaque = dpy.White
+	dpy.Transparent = dpy.Black
+	dpy.ScreenImage = &Image{
+		Display: &dpy,
+		R:       image.Rect(0, 0, opt.Width, opt.Height),
+		// m will be backed by screen.Buffer on size event.
 	}
 	if f, err := dpy.OpenFont(fontname); err != nil {
 		dpy.DefaultFont = defaultFont
@@ -74,6 +79,7 @@ func newWindow(label, winsize, fontname string) (*Display, screen.NewWindowOptio
 	dpy.mouse.C = make(chan Mouse, 0)
 	dpy.mouse.Resize = make(chan bool, 2) // Why 2? (copied from InitMouse).
 	dpy.mouse.last = time.Now()
+	dpy.mouse.Display = &dpy
 	dpy.keyboard.C = make(chan rune, 20)
 
 	return &dpy, opt

--- a/keyboard.go
+++ b/keyboard.go
@@ -16,8 +16,8 @@ const (
 	KeyDown  = 0x80
 	//KeyView      = 0x80
 	KeyPageDown = KeyFn | 0x13
-	//KeyInsert    = KeyFn | 0x14
-	KeyEnd = KeyFn | 0x18
+	KeyInsert   = KeyFn | 0x14
+	KeyEnd      = KeyFn | 0x18
 	//KeyAlt       = KeyFn | 0x15
 	//KeyShift     = KeyFn | 0x16
 	//KeyCtl       = KeyFn | 0x17

--- a/mouse.go
+++ b/mouse.go
@@ -14,8 +14,17 @@ type Mouse struct {
 }
 
 type Mousectl struct {
-	Mouse             // Store Mouse events here.
-	C      chan Mouse // Channel of Mouse events.
-	Resize chan bool  // Each received value signals a window resize (see the display.Attach method).
-	last   time.Time  // Time of last update.
+	Mouse              // Store Mouse events here.
+	C       chan Mouse // Channel of Mouse events.
+	Resize  chan bool  // Each received value signals a window resize (see the display.Attach method).
+	last    time.Time  // Time of last update.
+	Display *Display
+}
+
+// Read returns the next mouse event.
+func (mc *Mousectl) Read() Mouse {
+	mc.Display.Flush()
+	m := <-mc.C
+	mc.Mouse = m
+	return m
 }

--- a/pix.go
+++ b/pix.go
@@ -17,6 +17,7 @@ const (
 	NChan
 )
 
+var GREY8 = MakePix(CGrey, 8)
 var ARGB32 = MakePix(CAlpha, 8, CRed, 8, CGreen, 8, CBlue, 8) // stupid VGAs
 var ABGR32 = MakePix(CAlpha, 8, CBlue, 8, CGreen, 8, CRed, 8)
 


### PR DESCRIPTION
This gets [Edwood](https://github.com/rjkroege/edwood) somewhat working.
Edwood also needs some minor changes:

1. Change "9fans.net/go/draw" imports to duitdraw

2. Change default fonts to TTF fonts
   (e.g. "/usr/share/fonts/TTF/DejaVuSans.ttf@12pt")

3. It seems display.ScreenImage isn't ready for use until some events
   are consumed, so consume those events before first draw operation:
```
	<-mousectl.C
	<-mousectl.Resize
	display.ScreenImage.Draw(display.ScreenImage.R, display.White, nil, image.ZP)
```

CC: @rjkroege