### PR TITLE
Fix AllocImageMix

### DIFF
--- a/allocimagemix.go
+++ b/allocimagemix.go
@@ -16,10 +16,17 @@ func (d *Display) AllocImageMix(color1, color3 Color) *Image {
 	//	}
 
 	// use a solid color, blended using alpha
-	qmask, _ := d.AllocImage(image.Rect(0, 0, 1, 1), GREY8, true, 0x3F3F3FFF)
-	t, _ := d.AllocImage(image.Rect(0, 0, 1, 1), d.ScreenImage.Pix, true, color1)
-	b, _ := d.AllocImage(image.Rect(0, 0, 1, 1), d.ScreenImage.Pix, true, color3)
-	b.Draw(b.R, t, qmask, image.ZP)
-	t.Free()
-	return b
+	const (
+		q1 = 0x3f
+		q3 = 0xff - q1
+	)
+	c1 := color1.rgba()
+	c3 := color3.rgba()
+	r := (uint32(c1.R)*q1 + uint32(c3.R)*q3) / 0xff
+	g := (uint32(c1.G)*q1 + uint32(c3.G)*q3) / 0xff
+	b := (uint32(c1.B)*q1 + uint32(c3.B)*q3) / 0xff
+	a := uint32(c1.A)
+	c := Color(r<<24 | g<<16 | b<<8 | a)
+	img, _ := d.AllocImage(image.Rect(0, 0, 1, 1), d.ScreenImage.Pix, true, c)
+	return img
 }

--- a/allocimagemix_test.go
+++ b/allocimagemix_test.go
@@ -1,0 +1,38 @@
+package duitdraw
+
+import (
+	"image"
+	"reflect"
+	"testing"
+)
+
+func TestAllocImageMix(t *testing.T) {
+	tt := []struct {
+		color1, color3, mix Color
+	}{
+		{Palebluegreen, White, 0xEAFFFFFF},
+		{Paleyellow, White, 0xFFFFEAFF},
+		{0xAAAAAAAA, 0x55555555, 0x6A6A6AAA},
+		{0x55555555, 0xAAAAAAAA, 0x95959555},
+		{0x0A0A0A0A, 0x05050505, 0x0606060A},
+		{0x05050505, 0x0A0A0A0A, 0x08080805},
+	}
+	d, err := Init(nil, "", "", "")
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	r := image.Rect(0, 0, 1, 1)
+	for _, tc := range tt {
+		b := d.AllocImageMix(tc.color1, tc.color3)
+		if b.Display != d {
+			t.Errorf("image has display %p; exptected %p", b.Display, d)
+		}
+		if !reflect.DeepEqual(b.R, r) {
+			t.Errorf("image rect is %v; expected %v", b.R, r)
+		}
+		bm := image.NewUniform(tc.mix.rgba())
+		if !reflect.DeepEqual(bm, b.m) {
+			t.Errorf("image is %X; exptected %X", b.m, bm)
+		}
+	}
+}

--- a/color.go
+++ b/color.go
@@ -1,5 +1,7 @@
 package duitdraw
 
+import "image/color"
+
 // A Color represents an RGBA value, 8 bits per element. Red is the high 8
 // bits, green the next 8 and so on.
 type Color uint32
@@ -35,3 +37,12 @@ const (
 	Notacolor Color = 0xFFFFFF00
 	Nofill    Color = Notacolor
 )
+
+func (c Color) rgba() color.RGBA {
+	return color.RGBA{
+		R: uint8(c >> 24),
+		G: uint8(c >> 16),
+		B: uint8(c >> 8),
+		A: uint8(c),
+	}
+}

--- a/display.go
+++ b/display.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"image"
-	"image/color"
 	"image/draw"
 
 	"github.com/atotto/clipboard"
@@ -54,12 +53,7 @@ type Display struct {
 // Duit calls AllocImage to allocate colors for a single pixel rectange with repl = true.
 // We return a uniform image instead.
 func (d *Display) AllocImage(r image.Rectangle, pix Pix, repl bool, val Color) (*Image, error) {
-	c := color.RGBA{
-		R: uint8(val >> 24),
-		G: uint8(val >> 16),
-		B: uint8(val >> 8),
-		A: uint8(val),
-	}
+	c := val.rgba()
 
 	// Ignore repl if the image size is > 1.
 	if repl && r.Max.X == 1 && r.Max.Y == 1 {

--- a/image.go
+++ b/image.go
@@ -53,7 +53,7 @@ func (dst *Image) Draw(r image.Rectangle, src, mask *Image, p1 image.Point) {
 	case *image.RGBA:
 		im = m
 	default:
-		fmt.Println("shiny: image dst not implemented %T", m)
+		fmt.Printf("shiny: image dst not implemented %T\n", m)
 		return
 	}
 


### PR DESCRIPTION
Draw operation was failing because 1-pixel images are image.Uniform.
Avoid the draw operation.