### PR TITLE
Make sure ScreenImage buffer is allocated by Init

### DIFF
--- a/init.go
+++ b/init.go
@@ -25,10 +25,14 @@ func Init(errch chan<- error, fontname, label, winsize string) (*Display, error)
 			mainScreen = s
 			createWindow(dpy, opt, errch)
 		})
+		// make sure ScreenImage buffer is allocated
+		<-dpy.mouse.Resize
 		return dpy, nil
 	} else {
 		dpy, opt := newWindow(label, winsize, fontname)
 		go createWindow(dpy, opt, errch)
+		// make sure ScreenImage buffer is allocated
+		<-dpy.mouse.Resize
 		return dpy, nil
 	}
 }


### PR DESCRIPTION
Edwood starts drawing right after Init.
It crashes unless ScreenImage.m is properly initialized.