### PR TITLE
Correctly compute mouse.Msec time stamp

### DIFF
--- a/events.go
+++ b/events.go
@@ -147,8 +147,7 @@ func (d *Display) eventLoop(errch chan<- error) {
 func (d *Display) sendMouseEvent(e mouse.Event) {
 	d.mouse.Point.X = int(e.X)
 	d.mouse.Point.Y = int(e.Y)
-	t := time.Now()
-	d.mouse.Msec = uint32(t.Sub(d.mouse.last) * time.Millisecond)
-	d.mouse.last = t
+	t := time.Now().UnixNano() / (1000 * 1000) // Milliseconds
+	d.mouse.Msec = uint32(t)
 	d.mouse.C <- d.mouse.Mouse
 }

--- a/init.go
+++ b/init.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"strconv"
 	"strings"
-	"time"
 
 	"golang.org/x/exp/shiny/driver"
 	"golang.org/x/exp/shiny/screen"
@@ -82,7 +81,6 @@ func newWindow(label, winsize, fontname string) (*Display, screen.NewWindowOptio
 	}
 	dpy.mouse.C = make(chan Mouse, 0)
 	dpy.mouse.Resize = make(chan bool, 2) // Why 2? (copied from InitMouse).
-	dpy.mouse.last = time.Now()
 	dpy.mouse.Display = &dpy
 	dpy.keyboard.C = make(chan rune, 20)
 

--- a/mouse.go
+++ b/mouse.go
@@ -2,7 +2,6 @@ package duitdraw
 
 import (
 	"image"
-	"time"
 )
 
 // Mouse is the structure describing the current state of the mouse.
@@ -17,7 +16,6 @@ type Mousectl struct {
 	Mouse              // Store Mouse events here.
 	C       chan Mouse // Channel of Mouse events.
 	Resize  chan bool  // Each received value signals a window resize (see the display.Attach method).
-	last    time.Time  // Time of last update.
 	Display *Display
 }
 


### PR DESCRIPTION
The time stamp should be in milliseconds, so take system time in
nanoseconds, convert to milliseconds and take the lower 32-bits.

This makes Edwood correctly detect double-clicks.
If the difference between consecutive time stamps is less
than 500 milliseconds, Edwood interprets it as a double-click.