### PR TITLE
Fix font height computation

### DIFF
--- a/font.go
+++ b/font.go
@@ -65,9 +65,11 @@ func openFont(id FaceID) (*Font, error) {
 	faceCache.Lock()
 	defer faceCache.Unlock()
 	if f, ok := faceCache.m[id]; ok {
+		m := f.Metrics()
+		// TODO(fhs): Remove workaround for wrong m.Height.
 		return &Font{
 			FaceID: id,
-			Height: int(f.Metrics().Height / 64),
+			Height: (m.Ascent + m.Descent).Round(),
 			face:   f,
 		}, nil
 	}
@@ -93,9 +95,11 @@ func openFont(id FaceID) (*Font, error) {
 		face := pixFace{Face: truetype.NewFace(f, &opt)}
 		faceCache.m[id] = face
 
+		m := face.Metrics()
+		// TODO(fhs): Remove workaround for wrong m.Height.
 		return &Font{
 			FaceID: id,
-			Height: int((face.Metrics().Height + 32) / 64),
+			Height: (m.Ascent + m.Descent).Round(),
 			face:   face,
 		}, nil
 	}


### PR DESCRIPTION
The height that was being returned is the "recommended" amount of
vertical space, but it seems to be only slightly bigger than the Ascent.
It's small enough such that characters that take up space below the
baseline (e.g. 'g', 'y', 'j', 'p') gets cut off at the bottom.
(For reference, see
https://developer.apple.com/library/archive/documentation/TextFonts/Conceptual/CocoaTextArchitecture/Art/glyph_metrics_2x.png)

Plan9port's fontsrv also similarly sums up ascent and descent to compute
the height:
https://github.com/9fans/plan9port/blob/047fd921744f39a82a86d9370e03f7af511e6e84/src/cmd/fontsrv/x11.c#L80