### PR TITLE
Fix Font StringWidth

### DIFF
--- a/font.go
+++ b/font.go
@@ -134,7 +134,13 @@ func (f Font) StringSize(s string) image.Point {
 // StringWidth returns the number of horizontal pixels that would be occupied
 // by the string if it were drawn using the font.
 func (f *Font) StringWidth(s string) int {
-	dx := int(font.MeasureString(f.face, s)+32) / 64
+	dx := 0
+	for _, c := range s {
+		a, ok := f.face.GlyphAdvance(c)
+		if ok {
+			dx += a.Round()
+		}
+	}
 	return dx
 }
 

--- a/font_test.go
+++ b/font_test.go
@@ -1,0 +1,22 @@
+package duitdraw
+
+import "testing"
+
+func TestStringWidth(t *testing.T) {
+	tt := []string{
+		"Hello world!",
+		"I can eat glass and it doesn't hurt me.",
+		"私はガラスを食べられます。それは私を傷つけません。",
+		"আমি কাঁচ খেতে পারি, তাতে আমার কোনো ক্ষতি হয় না।",
+	}
+	for _, tc := range tt {
+		sum := 0
+		for _, c := range tc {
+			sum += defaultFont.StringWidth(string(c))
+		}
+		dx := defaultFont.StringWidth(tc)
+		if dx != sum {
+			t.Errorf("StringWidth(%q) is %v; expected %v", tc, dx, sum)
+		}
+	}
+}


### PR DESCRIPTION
Instead of rounding once for the full string, round for each character.