### PR TITLE
Workaround racy mouse event

### DIFF
--- a/mouse.go
+++ b/mouse.go
@@ -12,6 +12,13 @@ type Mouse struct {
 
 }
 
+// TODO: Mouse field is racy but okay.
+
+// Mousectl holds the interface to receive mouse events.
+// The Mousectl's Mouse is updated after send so it doesn't
+// have the wrong value if the sending goroutine blocks during send.
+// This means that programs should receive into Mousectl.Mouse
+// if they want full synchrony.
 type Mousectl struct {
 	Mouse              // Store Mouse events here.
 	C       chan Mouse // Channel of Mouse events.
@@ -23,6 +30,7 @@ type Mousectl struct {
 func (mc *Mousectl) Read() Mouse {
 	mc.Display.Flush()
 	m := <-mc.C
+	// Mouse field is racy. See Mousectl documentation.
 	mc.Mouse = m
 	return m
 }


### PR DESCRIPTION
This is just copying what 9fans.net/go/draw does:
https://github.com/9fans/go/blob/master/draw/mouse.go#L19

The issue I was having is that after using the mouse wheel, the Buttons
value was not being reset to 0. So, just moving the mouse without any
button presses was sending mouse wheel events.